### PR TITLE
Fixed a fence post error in the Display Custom Character function

### DIFF
--- a/firmware/OpenLCD/OpenLCD.ino
+++ b/firmware/OpenLCD/OpenLCD.ino
@@ -262,8 +262,8 @@ void updateDisplay()
       modeRecordCustomChar = true; //Change to this special mode
     }
 
-    //Display custom characters
-    else if (incoming >= 35 && incoming <= 43)
+    //Display custom characters, 8 characters allowed, 35 to 42 inclusive
+    else if (incoming >= 35 && incoming <= 42)
     {
       SerLCD.write(byte(incoming - 35)); //You write location zero to display customer char 0
     }


### PR DESCRIPTION
Fixed a bug (Fence Post error) in the Display Customer character command that allowed the user to request a ninth character when only 8 are allowed.  The upper limit in the if statement was off by one.  The allowable range should be 35 to 42, inclusive, not 35 to 43.