### PR TITLE
Add logic to print pipe if second control chracter is read

### DIFF
--- a/firmware/OpenLCD/OpenLCD.ino
+++ b/firmware/OpenLCD/OpenLCD.ino
@@ -267,7 +267,14 @@ void updateDisplay()
     {
       SerLCD.write(byte(incoming - 35)); //You write location zero to display customer char 0
     }
+    //If we get a second special setting character, then write it to the display 
+    //This allows us to print a pipe by escaping it as a double 
+    else if (incoming == SPECIAL_SETTING) {
+      SerLCD.write(incoming);
 
+      currentFrame[characterCount++] = incoming; //Record this character to the display buffer
+      if (characterCount == settingLCDwidth * settingLCDlines) characterCount = 0; //Wrap condition
+    }
     modeSetting = false;
   }
   else if (modeTWI == true)


### PR DESCRIPTION
This allows the user to print a pipe control character to the display by escaping the control character as a double pipe